### PR TITLE
Allow automatic value for lgap_id

### DIFF
--- a/esphome/components/lgap/climate/__init__.py
+++ b/esphome/components/lgap/climate/__init__.py
@@ -20,7 +20,7 @@ CONF_ZONE_NUMBER = "zone"
 CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(LGAP_HVAC_Climate),
-        cv.Required(CONF_LGAP_ID): cv.use_id(LGAP),
+        cv.GenerateID(CONF_LGAP_ID): cv.use_id(LGAP),
         cv.Optional(CONF_ZONE_NUMBER, default=0): cv.All(cv.int_),
     }
 ).extend(cv.COMPONENT_SCHEMA)


### PR DESCRIPTION
Changing this to GenerateID means that ESPHome will automatically use the id of the lgap component if there is only 1. It will give a validation error if there are multiple lgap components with a message telling the user to choose one and specify in config.