### PR TITLE
PI-485 board allow custom first byte for TX sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/settings.json
 **.DS_Store
+__pycache__/

--- a/esphome/components/lgap/__init__.py
+++ b/esphome/components/lgap/__init__.py
@@ -20,6 +20,7 @@ CONF_LGAP_ID = "lgap_id"
 CONF_RECEIVE_WAIT_TIME = "receive_wait_time"
 CONF_LOOP_WAIT_TIME = "loop_wait_time"
 CONF_FLOW_CONTROL_PIN = "flow_control_pin"
+CONF_TX_BYTE_0 = "tx_byte_0"
 
 #build schema
 CONFIG_SCHEMA = uart.UART_DEVICE_SCHEMA.extend(
@@ -28,6 +29,7 @@ CONFIG_SCHEMA = uart.UART_DEVICE_SCHEMA.extend(
         cv.Optional(CONF_FLOW_CONTROL_PIN): pins.gpio_output_pin_schema,
         cv.Optional(CONF_RECEIVE_WAIT_TIME, default="500ms"): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_LOOP_WAIT_TIME, default="500ms"): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_TX_BYTE_0, default=0): cv.int_range(0, 255),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -49,3 +51,6 @@ async def to_code(config):
     #times
     cg.add(var.set_receive_wait_time(config[CONF_RECEIVE_WAIT_TIME]))
     cg.add(var.set_loop_wait_time(config[CONF_LOOP_WAIT_TIME]))
+
+    # TX
+    cg.add(var.set_tx_byte_0(config[CONF_TX_BYTE_0]))

--- a/esphome/components/lgap/climate/lgap_climate.cpp
+++ b/esphome/components/lgap/climate/lgap_climate.cpp
@@ -226,7 +226,7 @@ namespace esphome
       // build payload in message buffer
       message.push_back(0x80);
       message.push_back(0);
-      message.push_back(0xA0);
+      message.push_back(request_id);
       message.push_back(this->zone_number);
       message.push_back(write_state | this->power_state_);
       message.push_back(this->mode_ | (this->swing_ << 3) | (this->fan_speed_ << 4));

--- a/esphome/components/lgap/climate/lgap_climate.cpp
+++ b/esphome/components/lgap/climate/lgap_climate.cpp
@@ -371,9 +371,7 @@ namespace esphome
           this->current_temperature_ = current_temperature;
           this->current_temperature = current_temperature;
           publish_update = true;
-        }
-        else
-        {
+        } else {
           ESP_LOGD(TAG, "Temperature update time hasn't lapsed. Ignoring temperature difference...");
         }
       }

--- a/esphome/components/lgap/climate/lgap_climate.cpp
+++ b/esphome/components/lgap/climate/lgap_climate.cpp
@@ -224,9 +224,9 @@ namespace esphome
       int write_state = this->write_update_pending ? 2 : 0;
 
       // build payload in message buffer
+      message.push_back(0x80);
       message.push_back(0);
-      message.push_back(0);
-      message.push_back(request_id);
+      message.push_back(0xA0);
       message.push_back(this->zone_number);
       message.push_back(write_state | this->power_state_);
       message.push_back(this->mode_ | (this->swing_ << 3) | (this->fan_speed_ << 4));

--- a/esphome/components/lgap/climate/lgap_climate.cpp
+++ b/esphome/components/lgap/climate/lgap_climate.cpp
@@ -224,7 +224,7 @@ namespace esphome
       int write_state = this->write_update_pending ? 2 : 0;
 
       // build payload in message buffer
-      message.push_back(0x80);
+      message.push_back(this->parent_->get_tx_byte_0());
       message.push_back(0);
       message.push_back(request_id);
       message.push_back(this->zone_number);
@@ -371,7 +371,9 @@ namespace esphome
           this->current_temperature_ = current_temperature;
           this->current_temperature = current_temperature;
           publish_update = true;
-        } else {
+        }
+        else
+        {
           ESP_LOGD(TAG, "Temperature update time hasn't lapsed. Ignoring temperature difference...");
         }
       }

--- a/esphome/components/lgap/lgap.cpp
+++ b/esphome/components/lgap/lgap.cpp
@@ -26,6 +26,7 @@ namespace esphome
         ESP_LOGCONFIG(TAG, "Flow control pin not set.");
       }
 
+      ESP_LOGCONFIG(TAG, "  First TX byte: 0x%02X", this->tx_byte_0_);
       ESP_LOGCONFIG(TAG, "  Loop wait time: %dms", this->loop_wait_time_);
       ESP_LOGCONFIG(TAG, "  Receive wait time: %dms", this->receive_wait_time_);
       ESP_LOGCONFIG(TAG, "  Child devices: %d", this->devices_.size());

--- a/esphome/components/lgap/lgap.h
+++ b/esphome/components/lgap/lgap.h
@@ -34,6 +34,9 @@ namespace esphome
 
         void set_flow_control_pin(GPIOPin *flow_control_pin) { this->flow_control_pin_ = flow_control_pin; }
         void set_receive_wait_time(uint16_t time_in_ms) { this->receive_wait_time_ = time_in_ms; }
+        void set_tx_byte_0(uint8_t tx_byte_0) { this->tx_byte_0_ = tx_byte_0; }
+        uint8_t get_tx_byte_0() const { return this->tx_byte_0_; }
+
         void register_device(LGAPDevice *device)
         {
           ESP_LOGD(TAG, "Registering device");
@@ -51,6 +54,8 @@ namespace esphome
 
         uint16_t loop_wait_time_{500};
         uint16_t receive_wait_time_{500};
+
+        uint8_t tx_byte_0_{0};
 
         // used for keeping track of req/resp pairs
         uint8_t last_request_id_{250};


### PR DESCRIPTION
addressing issue https://github.com/jourdant/esphome-lgap/issues/10
PI-485 board expects first byte to be 0x80 and will not "blink green LED" otherwise.
thanks to https://github.com/jourdant/esphome-lgap/blob/e55d422305c4d41485d46adde522608ef3296421/images/LGAP.pdf

successfully tested with rather old ODU FM40AH UH0 (AGUW406FAO) + 4 IDU + PI-485 board + ATOM M5 & rs485
- pi-485 dip: 1,4,5 ON
- set unique addresses with remote for each indoor unit (see LGAP.pdf) - otherwise no red LED will show you how many IDU it found
- untill this PR is merged - use forked git source https://github.com/tolkachev/esphome-lgap
- set lgap.tx_byte_0: 0x80 in esphome.yaml
- no need to swap A&B lines


working snippet of esphome.yaml
```
esp32:
  board: m5stack-atom
  framework:
    type: arduino

external_components:
  - source:
      type: git
#    url: https://github.com/jourdant/esphome-lgap
      url: https://github.com/tolkachev/esphome-lgap
      ref: main
    components: [ "lgap"]
    refresh: 0sec

uart:
  id: lgap_uart1
  tx_pin:
    number: GPIO19
  rx_pin:
    number: GPIO22
  baud_rate: 4800
  data_bits: 8
  stop_bits: 1
  parity: NONE
#  debug:
#      direction: BOTH
#      dummy_receiver: true # this will prevent the code from actually reading bus, use with caution

lgap:
  - id: lgap1
    uart_id: lgap_uart1
    receive_wait_time: 1000ms
    tx_byte_0: 0x80

climate:
  - platform: lgap
    id: lgap_zone_1
    name: 'Salon'
    lgap_id: lgap1
    zone: 1
```

i'm not really into C++, sorry for obvious mistakes )
just invested too much in hardware before reading #10 to abandon this project


