### PR TITLE
Update ClimateTraits to newer feature flags

### DIFF
--- a/esphome/components/lgap/climate/lgap_climate.cpp
+++ b/esphome/components/lgap/climate/lgap_climate.cpp
@@ -58,10 +58,7 @@ namespace esphome
     esphome::climate::ClimateTraits LGAPHVACClimate::traits()
     {
       auto traits = climate::ClimateTraits();
-      traits.set_supports_current_temperature(true);
-      traits.set_supports_two_point_target_temperature(false);
-      traits.set_supports_current_humidity(false);
-      traits.set_supports_target_humidity(false);
+      traits.add_feature_flags(climate::ClimateFeature::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
 
       traits.set_supported_modes({
           climate::CLIMATE_MODE_OFF,


### PR DESCRIPTION
Update lgap_climate.cpp to remove use of deprecated setter methods in the esphome::climate::ClimateTraits class, which were replaced with a feature flags approach in recent ESPHome versions (around 2025.11.0).