### PR TITLE
Removed legacy calls for traits and implemented climate action traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,19 @@ climate:
 ```
 
 If you want to add extra zones, you can reference the same ```lgap_id``` on the climate component. It is also possible to have multiple LGAP protocol components using different UART components in the same configuration.
+
+
+## Climate Action Inference
+
+Home Assistant allows current action of climate devices to be reported. This shows up in the climate card as something like "Heating to 24°C" or "Idle" etc. I haven't found in the LGAP protocol whether the compressor or heating element is actively running. This component **infers** the current action based on the operating mode and temperature comparison:
+
+| Mode | Reported Action |
+|------|-----------------|
+| **Off** | `OFF` |
+| **Cool** | `COOLING` if current temp > target temp, otherwise `IDLE` |
+| **Heat** | `HEATING` if current temp < target temp, otherwise `IDLE` |
+| **Heat/Cool (Auto)** | `COOLING` if current > target, `HEATING` if current < target, otherwise `IDLE` |
+| **Dry** | `DRYING` (always, when active) |
+| **Fan Only** | `FAN` (always, when active) |
+
+**Note:** This is an approximation. The actual compressor state may differ due to factors like defrost cycles, minimum run times, or thermostat deadbands within the unit. If you discover a byte in the LGAP protocol that indicates actual compressor status, please open an issue or PR!

--- a/esphome/components/lgap/climate/lgap_climate.cpp
+++ b/esphome/components/lgap/climate/lgap_climate.cpp
@@ -58,10 +58,7 @@ namespace esphome
     esphome::climate::ClimateTraits LGAPHVACClimate::traits()
     {
       auto traits = climate::ClimateTraits();
-      traits.set_supports_current_temperature(true);
-      traits.set_supports_two_point_target_temperature(false);
-      traits.set_supports_current_humidity(false);
-      traits.set_supports_target_humidity(false);
+      traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | climate::CLIMATE_SUPPORTS_ACTION);
 
       traits.set_supported_modes({
           climate::CLIMATE_MODE_OFF,
@@ -291,6 +288,7 @@ namespace esphome
         if (power_state == 0)
         {
           this->mode = climate::CLIMATE_MODE_OFF;
+          this->action = climate::CLIMATE_ACTION_OFF;
         }
 
         // update state
@@ -374,6 +372,48 @@ namespace esphome
         } else {
           ESP_LOGD(TAG, "Temperature update time hasn't lapsed. Ignoring temperature difference...");
         }
+      }
+
+      // determine climate action based on mode and temperature
+      climate::ClimateAction new_action = climate::CLIMATE_ACTION_OFF;
+      if (this->power_state_ == 1)
+      {
+        switch (this->mode_)
+        {
+          case 0: // cool
+            new_action = (this->current_temperature > this->target_temperature)
+                ? climate::CLIMATE_ACTION_COOLING
+                : climate::CLIMATE_ACTION_IDLE;
+            break;
+          case 1: // dry
+            new_action = climate::CLIMATE_ACTION_DRYING;
+            break;
+          case 2: // fan only
+            new_action = climate::CLIMATE_ACTION_FAN;
+            break;
+          case 3: // heat_cool (auto)
+            if (this->current_temperature > this->target_temperature)
+              new_action = climate::CLIMATE_ACTION_COOLING;
+            else if (this->current_temperature < this->target_temperature)
+              new_action = climate::CLIMATE_ACTION_HEATING;
+            else
+              new_action = climate::CLIMATE_ACTION_IDLE;
+            break;
+          case 4: // heat
+            new_action = (this->current_temperature < this->target_temperature)
+                ? climate::CLIMATE_ACTION_HEATING
+                : climate::CLIMATE_ACTION_IDLE;
+            break;
+          default:
+            new_action = climate::CLIMATE_ACTION_IDLE;
+            break;
+        }
+      }
+
+      if (this->action != new_action)
+      {
+        this->action = new_action;
+        publish_update = true;
       }
 
       // send update to home assistant with all the changed variables


### PR DESCRIPTION
I've cleared the compilation warnings by updating to the new method of specifying traits. Two main changes in this PR:

1. Removed the legacy calls to ```set_supports_current_temperature```, ```set_supports_two_point_target_temperature``` etc and replaced with ```add_feature_flags```
2. Added ```climate::CLIMATE_SUPPORTS_ACTION``` feature flag. This enables HA to report things like "Heating to x degrees", "Idle" etc. For now this is inferred based on the current operation of the unit and then only point it may become a little inaccurate is if you're on heat/cool or auto mode where it's inferring whether we're heating or cooling. I think it is a low risk of being wrong for the nice UI benefit that we get.